### PR TITLE
ES-837838 : The proper URL link were mapped.

### DIFF
--- a/ej2-javascript/listview/ej2-javascript-listview-toc.html
+++ b/ej2-javascript/listview/ej2-javascript-listview-toc.html
@@ -35,6 +35,6 @@ ListView
 <li><a href="/ej2-javascript/listview/how-to/integrate-pager-component-with-listview">Integrate Pager Component with ListView</a></li>
 </ul>
 </li>
-<li><a href="https://ej2.syncfusion.com/javascript/documentation/api/listview/">API Reference</a></li>
+<li><a href="https://ej2.syncfusion.com/javascript/documentation/api/list-view/">API Reference</a></li>
 </ul>
 </li>

--- a/ej2-javascript/listview/ej2-typescript-listview-toc.html
+++ b/ej2-javascript/listview/ej2-typescript-listview-toc.html
@@ -35,6 +35,6 @@ ListView
 <li><a href="/ej2-typescript/listview/how-to/integrate-pager-component-with-listview">Integrate Pager Component with ListView</a></li>
 </ul>
 </li>
-<li><a href="https://ej2.syncfusion.com/documentation/api/listview/">API Reference</a></li>
+<li><a href="https://ej2.syncfusion.com/documentation/api/list-view/">API Reference</a></li>
 </ul>
 </li>


### PR DESCRIPTION
The URL link for the ListView API reference in TypeScript and JavaScript documentation was corrected, and a PR was created for the changes.
Improper link :
https://ej2.syncfusion.com/javascript/documentation/api/listview/
https://ej2.syncfusion.com/documentation/api/listview/
Proper link :
https://ej2.syncfusion.com/javascript/documentation/api/list-view/
https://ej2.syncfusion.com/documentation/api/list-view/